### PR TITLE
Use official youtube feed URL

### DIFF
--- a/xExtension-YouTubeChannel2RssFeed/extension.php
+++ b/xExtension-YouTubeChannel2RssFeed/extension.php
@@ -31,7 +31,7 @@ class YouTubeChannel2RssFeedExtension extends Minz_Extension {
 	public static function CntYTRssHookBeforeInsertFeed($feed) {
 		if (self::$channelID != '') {
 			$lTxt = $feed->name() ? $feed->name() : 'YouTubeChannel2Rss by CN-Tools';
-			$url = 'https://www.scriptbarrel.com/xml.cgi?channel_id=' . self::$channelID . '&name=' . urlencode($lTxt);
+			$url = 'https://www.youtube.com/feeds/videos.xml?channel_id=' . self::$channelID;
 			$feed->_url($url);
 		}
 		return $feed;


### PR DESCRIPTION
I don't see why this uses a third party feed instead of just using the feeds that YouTube provides itself. This PR would fix that.