### PR TITLE
Bugfix filter title extension

### DIFF
--- a/xExtension-FilterTitle/extension.php
+++ b/xExtension-FilterTitle/extension.php
@@ -58,10 +58,10 @@ class FilterTitleExtension extends Minz_Extension {
                 }
             }
         }
- 
+
         return $entry;
     }
- 
+
     private function isPatternFound(string $title, string $pattern): bool {
         if (1 === preg_match($pattern, $title)) {
             return true;
@@ -70,7 +70,7 @@ class FilterTitleExtension extends Minz_Extension {
         }
         return false;
     }
- 
+
     public function getBlacklistData() {
         if ($this->getSystemConfigurationValue('check_type') == '0') {
             // 20240311 - Until version v0.0.2 there was only blacklist OR whitelist availabe
@@ -79,7 +79,7 @@ class FilterTitleExtension extends Minz_Extension {
             return implode(PHP_EOL, $this->getSystemConfigurationValue('blacklist') ?? []);
         }
     }
- 
+
     public function getWhitelistData() {
         if ($this->getSystemConfigurationValue('check_type') == '1') {
             // 20240311 - Until version v0.0.2 there was only blacklist OR whitelist availabe

--- a/xExtension-FilterTitle/extension.php
+++ b/xExtension-FilterTitle/extension.php
@@ -12,9 +12,9 @@ class FilterTitleExtension extends Minz_Extension {
 
         if (Minz_Request::isPost()) {
             $configuration = [
-                'blacklist' => array_filter(Minz_Request::paramTextToArray('blacklist', [])),
+                'blacklist' => array_filter(Minz_Request::paramTextToArray('blacklist', true)),
                 'mark_as_read' => Minz_Request::paramString('mark_as_read'),
-                'whitelist' => array_filter(Minz_Request::paramTextToArray('whitelist', [])),
+                'whitelist' => array_filter(Minz_Request::paramTextToArray('whitelist', true)),
             ];
             $this->setSystemConfiguration($configuration);
         }
@@ -58,10 +58,10 @@ class FilterTitleExtension extends Minz_Extension {
                 }
             }
         }
-
+ 
         return $entry;
     }
-
+ 
     private function isPatternFound(string $title, string $pattern): bool {
         if (1 === preg_match($pattern, $title)) {
             return true;
@@ -70,7 +70,7 @@ class FilterTitleExtension extends Minz_Extension {
         }
         return false;
     }
-
+ 
     public function getBlacklistData() {
         if ($this->getSystemConfigurationValue('check_type') == '0') {
             // 20240311 - Until version v0.0.2 there was only blacklist OR whitelist availabe
@@ -79,7 +79,7 @@ class FilterTitleExtension extends Minz_Extension {
             return implode(PHP_EOL, $this->getSystemConfigurationValue('blacklist') ?? []);
         }
     }
-
+ 
     public function getWhitelistData() {
         if ($this->getSystemConfigurationValue('check_type') == '1') {
             // 20240311 - Until version v0.0.2 there was only blacklist OR whitelist availabe


### PR DESCRIPTION
fix: use correct boolean parameter for paramTextToArray in FilterTitle extension
Changed the second argument of Minz_Request::paramTextToArray from array to boolean (true) for both blacklist and whitelist in handleConfigureAction, ensuring compatibility with the expected method signature and preventing type errors.